### PR TITLE
Added a explicit switch for IPv6

### DIFF
--- a/zy.conf
+++ b/zy.conf
@@ -9,6 +9,9 @@ DUTPASS="KeepThisSecret"
 # Enable this switch if the DUT uses VoIP
 USEVOIP=1
 
+# Enable this switch if the DUT offers IPv6
+V6=1
+
 #################################################
 # Some system settings                          #
 #################################################

--- a/zywatch.sh
+++ b/zywatch.sh
@@ -61,8 +61,7 @@ GUIACCESS=0
 doReadConfig()
 {
   . ${CONFIGFILE}
-  V6=0
-  [ ! -z $(cat /etc/modules |grep ipv6) ] && V6=1
+  [ -z $V6 ] && V6=1
   HOSTNAME=$(cat /etc/hostname)
   [ -z $LANIF ] && LANIF="eth0"
 }


### PR DESCRIPTION
* Debian does not load IPv6 modules explicit via /etc/modules anymore
* Also it is black magic to load the value implicit
* Added a config file switch
* for backwards compatibillity enable IPv6 if config file does not contain the switch