### PR TITLE
Make the IP of the DUT configurable

### DIFF
--- a/zywatch.sh
+++ b/zywatch.sh
@@ -397,6 +397,10 @@ doReadConfig
 
 # find the DUT
 DEFAULT=$(ip route |grep default |grep default |awk '{print $3}')
+if [ ! -z ${DUTIP} ];then
+  DEFAULT=${DUTIP}
+fi
+
 LANIF=$(ip route |grep default |grep default |awk '{print $5}')
 if [ -z "${DEFAULT}" ];then
   echo " can't find DUT"


### PR DESCRIPTION
DUT IP must not be the same as default gateway. Made the parameter optionally configurable.