### PR TITLE
Fixed broken apt command

### DIFF
--- a/zywatch.sh
+++ b/zywatch.sh
@@ -119,7 +119,7 @@ doSetup()
 
     # install dependencies
     apt-get update
-    apt-get install -y "${DEPENDENCIES}"
+    apt-get install -y ${DEPENDENCIES}
 
     # prepare cronjob
     echo "@reboot root ${ZYPATH}/${SCRIPTNAME} > /dev/null" > "${cronjob}"


### PR DESCRIPTION
If packages are surrounded by double quotes, they are considered
to be one package.