### PR TITLE
Fixed delimiter of send_nsca

### DIFF
--- a/zywatch.sh
+++ b/zywatch.sh
@@ -107,7 +107,7 @@ doSend()
     if [ ! -z "${1}" ]; then
         echo "password=${MONITORINGPASSWD}" > /etc/send_nsca.cfg
         echo "encryption_method=3" >> /etc/send_nsca.cfg
-        echo "${HOSTNAME},${1},${2},${3}"| /usr/sbin/send_nsca -H "${MONITORINGTARGET}" -p 5667 -d , -c /etc/send_nsca.cfg > /dev/null 2>&1
+        echo "${HOSTNAME}	${1}	${2}	${3}"| /usr/sbin/send_nsca -H "${MONITORINGTARGET}" -p 5667 -c /etc/send_nsca.cfg > /dev/null 2>&1
     fi
 }
 


### PR DESCRIPTION
-d option is broken in current raspian, need to use tab as delimiter again.

see: https://github.com/NagiosEnterprises/nsca/issues/44